### PR TITLE
Add ability to use markdown in sections.

### DIFF
--- a/source/section/macros/main.tid
+++ b/source/section/macros/main.tid
@@ -1,10 +1,13 @@
 code-body: yes
+created: 20231204222018230
+modified: 20240103225948105
 tags: 
 title: $:/plugins/kookma/section/macros/main
 type: text/vnd.tiddlywiki
 
 \define pattern() \n\s*(?=!{1,$(hn)$}[^!])
-
+\define patternMD() \n\s*(?=#{1,$(hn)$}[^#])
+ 
 \define sectionizeSingleTiddler(sourceTiddler)
 \import $:/plugins/kookma/section/macros/definition
 <$vars hn={{{ [<se-hlevelTid>get[text]else[2]] }}} > <!-- default level of headings 2 -->

--- a/source/section/macros/sectionizer.tid
+++ b/source/section/macros/sectionizer.tid
@@ -1,20 +1,27 @@
+code-body: yes
+created: 20231204010031507
+modified: 20240103230247559
 tags: $:/tags/Macro
 title: $:/plugins/kookma/section/macros/sectionizer
 type: text/vnd.tiddlywiki
 
 \define sectionizer(source, pattern:"")
 \import [all[tiddlers+shadows]tag[$:/tags/Section/Macro]]
-<$vars source=<<__source__>> 
+<$let source=<<__source__>> 
        sourceText={{{[<__source__>get[text]]}}} 
-       pattern=<<__pattern__>> nonWhitespace="[^\s]" lbr="""
+       splitChar={{{ [{!!type}match[text/markdown]then[#]] [[!]] +[first[]] }}}
+       pattern={{{[<splitChar>match[#]then<patternMD>else<__pattern__>] }}} 
+       nonWhitespace="[^\s]"
+       sourceType={{{[<__source__>get[type]]}}} 
+       lbr="""
 """><article class="se-article">
 <$list counter=counter variable=currentSection
        filter="[<sourceText>splitregexp<pattern>!is[blank]regexp<nonWhitespace>]">
-<$set name=seTemplate filter="[<currentSection>trim:prefix[]prefix[!]]" 
+<$set name=seTemplate filter="[<currentSection>trim:prefix[]prefix<splitChar>]" 
       value="$:/plugins/kookma/section/templates/section" 
       emptyValue="$:/plugins/kookma/section/templates/foreword">
   <$transclude tiddler=<<seTemplate>> mode=inline/>
 </$set>
 </$list>
-</article></$vars>
+</article></$let>
 \end

--- a/source/section/templates/section-body.tid
+++ b/source/section/templates/section-body.tid
@@ -1,4 +1,6 @@
 code-body: yes
+created: 20231204173139849
+modified: 20240103230046617
 tags: todo
 title: $:/plugins/kookma/section/templates/section-body
 type: text/vnd.tiddlywiki
@@ -6,7 +8,10 @@ type: text/vnd.tiddlywiki
 \define editActions()
 <!-- action when edit button is clicked -->
 <$action-setfield $tiddler=<<stateTid>> $index=<<counter>> $value="edit" />
-<$action-setfield $tiddler=<<editTid>> $field=text $value=<<currentSection>> throttle.refresh=""/>
+<$action-setfield $tiddler=<<editTid>> $field=text $value=<<currentSection>>
+    type=<<sourceType>> 
+test="I was here"
+ throttle.refresh=""/>
 \end
 
 \define xxdoneActions()

--- a/source/section/templates/section-header.tid
+++ b/source/section/templates/section-header.tid
@@ -1,11 +1,13 @@
 code-body: yes
+created: 20231204221309235
+modified: 20240103230528721
 tags: 
 title: $:/plugins/kookma/section/templates/section-header
 type: text/vnd.tiddlywiki
 
 \whitespace trim
-\define header() <$(hn)$><$transclude tiddler={{{ [<sectionHeader>trim:prefix[]trim:prefix[!]] }}} field=title mode=inline/></$(hn)$>
-
-<$set name=hn filter="[<sectionHeader>trim:prefix[]search-replace::regexp[(^!*).*],[$1]length[]addprefix[h]]" ><<header>></$set>
+\define header() <$(hn)$><$transclude tiddler={{{ [<sectionHeader>trim:prefix[]trim:prefix<splitChar>] }}} field=title mode=inline/></$(hn)$>
+\define regCharSplit() (^$(splitChar)$*).*
+<$set name=hn filter="[<sectionHeader>trim:prefix[]search-replace::regexp<regCharSplit>,[$1]length[]addprefix[h]]" ><<header>>
 
 <!-- the trim:prefix[] handles the extra leading spaces, tabs for any heading -->

--- a/source/section/templates/view.tid
+++ b/source/section/templates/view.tid
@@ -1,6 +1,8 @@
 code-body: yes
+created: 20231204202854683
+modified: 20240103230726844
 tags: 
 title: $:/plugins/kookma/section/templates/view
 type: text/vnd.tiddlywiki
 
-<$transclude tiddler=<<sectionBody>> field=title mode="block"/>
+<$wikify text=<<sectionBody>> type={{!!type}} mode="block" name="OUT" output="html"><<OUT>></$wikify>


### PR DESCRIPTION
This modifies 5 tiddlers in the section plugin so that it can also be used with markdown tiddlers. 

One complication is that it uses the wikify widget instead of transclusion. So there may be performance concerns? 

You can review a demo at:

https://sections-with-markdown.tiddlyhost.com/
